### PR TITLE
Skaivan

### DIFF
--- a/Algorithm/financial_loss_2.py
+++ b/Algorithm/financial_loss_2.py
@@ -3,9 +3,10 @@ from Models.XG_Boost.adaptive_xgboost import execute_evaluation, execute_adaptiv
 from Utils.process_data import process_data_lagged_rolling_stats
 import Constants.parameters as prms
 
-def execute_purchase_strategy_v2(data,dailyConsumption, maxDays, forecast_days):
 
-    actual_values, predictions, forecast, adaptive_xgb_pred  = execute_adaptive_xgboost(data, forecast_days, hyperparams=prms.xgboost_params_4Y)
+def execute_purchase_strategy_v2(data, dailyConsumption, maxDays, forecast_days):
+    actual_values, predictions, forecast = execute_adaptive_xgboost(data, forecast_days,
+                                                                    hyperparams=prms.xgboost_params_4Y)
 
     def optimum_purchase(pred):
         curStock = 0
@@ -24,7 +25,6 @@ def execute_purchase_strategy_v2(data,dailyConsumption, maxDays, forecast_days):
                     break
             curStock -= 1
         return stockStatement
-
 
     def compute_purchase_cost(stockStatement):
         stockToBuy = stockStatement[0]

--- a/Execute/execute.py
+++ b/Execute/execute.py
@@ -40,20 +40,23 @@ def forecast_pipeline():
     features_dataset.last('4Y')
 
     'TUNE HYPER-PARAMETERS'
-    # params, actual_data, predictions = tune_xgboost_hyperparameters(features_dataset)
+    params, actual_data, predictions = tune_xgboost_hyperparameters(features_dataset)
     lstm_params = tune_lstm_hyperparameters(features_dataset.copy(), no_trials=100)
-    # lstm_params = prms.lstm_parameters_4Y
+    lstm_params = prms.lstm_parameters_4Y
+
     'EXECUTE MODELS'
     sarimax_forecast = execute_sarimax(features_dataset.copy(), prms.FORECASTING_DAYS)
     prophet_forecast = execute_prophet(features_dataset.copy(), prms.FORECASTING_DAYS)
     ets_predictions = execute_ets(features_dataset.copy(), prms.FORECASTING_DAYS)
     lstm_forecast = execute_lstm(features_dataset.copy(), prms.FORECASTING_DAYS, lstm_params)
-    xgboost_predictions, xgboost_forecast = execute_adaptive_xgboost(features_dataset.copy(), prms.FORECASTING_DAYS, prms.xgboost_params_4Y)
+    xgboost_predictions, xgboost_forecast = execute_adaptive_xgboost(features_dataset.copy(), prms.FORECASTING_DAYS,
+                                                                     prms.xgboost_params_4Y)
     lgbm_predictions, lgbm_forecast = execute_lgbm(processed_data.copy(), prms.FORECASTING_DAYS)
 
     'EXECUTE PURCHASE STRATEGY'
     # execute_purchase_strategy(lgbm_predictions, actual_data, 10, 0, 400)
-    # execute_purchase_strategy_v2(features_dataset.copy(),2330,40,prms.FORECASTING_DAYS)
+    execute_purchase_strategy_v2(features_dataset.copy(), 23350, 40, prms.FORECASTING_DAYS)
+
 
 def create_features_dataset(processed_data):
     """Function to create a dataset using selected features based on correlation methods."""
@@ -75,8 +78,8 @@ def read_data():
 
     data = pd.read_csv('../Data/Price_Data.csv', parse_dates=['Date'], date_parser=custom_date_parser)
     processed_data = process_data_lagged(data, prms.FORECASTING_DAYS)
-    cols_to_remove = (set(processed_data.columns) & set(data.columns)) - {"Output"}
-    processed_data = processed_data.drop(columns=cols_to_remove)
+    # cols_to_remove = (set(processed_data.columns) & set(data.columns)) - {"Output"}
+    # processed_data = processed_data.drop(columns=cols_to_remove)
     test = processed_data['Output'][int(0.8 * len(processed_data)):]
 
     return processed_data, test

--- a/Execute/execute.py
+++ b/Execute/execute.py
@@ -27,6 +27,7 @@ from DL_Models.LSTM.lstm_tuning import tune_lstm_hyperparameters
 
 # Importing financial loss version 2
 from Algorithm.financial_loss_2 import execute_purchase_strategy_v2
+from Algorithm.financial_loss import execute_purchase_strategy
 
 
 def forecast_pipeline():
@@ -49,12 +50,11 @@ def forecast_pipeline():
     prophet_forecast = execute_prophet(features_dataset.copy(), prms.FORECASTING_DAYS)
     ets_predictions = execute_ets(features_dataset.copy(), prms.FORECASTING_DAYS)
     lstm_forecast = execute_lstm(features_dataset.copy(), prms.FORECASTING_DAYS, lstm_params)
-    xgboost_predictions, xgboost_forecast = execute_adaptive_xgboost(features_dataset.copy(), prms.FORECASTING_DAYS,
-                                                                     prms.xgboost_params_4Y)
+    execute_adaptive_xgboost(features_dataset.copy(), prms.FORECASTING_DAYS, prms.xgboost_params_4Y)
     lgbm_predictions, lgbm_forecast = execute_lgbm(processed_data.copy(), prms.FORECASTING_DAYS)
 
     'EXECUTE PURCHASE STRATEGY'
-    # execute_purchase_strategy(lgbm_predictions, actual_data, 10, 0, 400)
+    execute_purchase_strategy(lgbm_predictions, actual_data, 10, 0, 400)
     execute_purchase_strategy_v2(features_dataset.copy(), 23350, 40, prms.FORECASTING_DAYS)
 
 

--- a/Models/XG_Boost/adaptive_xgboost.py
+++ b/Models/XG_Boost/adaptive_xgboost.py
@@ -132,15 +132,11 @@ def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
         if i < forecast_days - 1:
             concatenated_data.reset_index(inplace=True, drop=False)
             concatenated_data.rename(columns={'index': 'Date'}, inplace=True)
-            concatenated_data = process_data_lagged_rolling_stats(concatenated_data, forecast_days)
+            concatenated_data = process_data_lagged(concatenated_data, forecast_days)
 
-            future_data_cols = future_data.columns.tolist()
-
-            relevant_rows = concatenated_data.iloc[-(forecast_days - i):].copy()
-            relevant_rows = relevant_rows[future_data_cols]
-
-            num_rows_to_update = min(len(future_data.iloc[i + 1:]), len(relevant_rows))
-            future_data.iloc[i + 1:i + 1 + num_rows_to_update] = relevant_rows.iloc[:num_rows_to_update].values
+            next_day_row = concatenated_data.iloc[-1].copy()
+            next_day_row = next_day_row[future_data.columns]
+            future_data.iloc[i + 1] = next_day_row
 
         print(future_data.to_string())
 
@@ -151,4 +147,4 @@ def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
 
     print(future_data['Output'])
 
-    return actual_values, predictions, future_data['Output'],
+    return actual_values, predictions, future_data['Output']

--- a/Models/XG_Boost/adaptive_xgboost.py
+++ b/Models/XG_Boost/adaptive_xgboost.py
@@ -37,10 +37,17 @@ def execute_evaluation(subset_data, hyperparams):
         train_data = subset_data.iloc[window_start:window_start + window_size]
         val_data = subset_data.iloc[window_start + window_size:window_start + window_size + 1]
 
-        X_train, y_train = train_data.drop(columns='Output'), train_data['Output']
-        X_val, y_val = val_data.drop(columns='Output'), val_data['Output']
+        X_train = train_data.drop(columns='Output')
+        X_train = X_train[[col for col in X_train.columns if '_lag' in col]]
+
+        X_val = val_data.drop(columns='Output')
+        X_val = X_val[[col for col in X_val.columns if '_lag' in col]]
+
+        y_train = train_data['Output']
+        y_val = val_data['Output']
 
         model.fit(X_train, y_train, eval_set=[(X_train, y_train), (X_val, y_val)])
+        trained_feature_order = X_train.columns.tolist()
 
         predictions.extend(model.predict(X_val))
         actual_values.extend(y_val.values)
@@ -50,7 +57,7 @@ def execute_evaluation(subset_data, hyperparams):
     print(mean_squared_error(actual_values, predictions))
     print(mean_absolute_error(actual_values, predictions))
 
-    return actual_values, predictions
+    return actual_values, predictions, trained_feature_order
 
 
 def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
@@ -69,11 +76,12 @@ def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
     window_size = int(0.5 * len(subset_data))
 
     # Retrieve actual values and predictions for the subset data
-    actual_values, predictions = execute_evaluation(subset_data, hyperparams)
+    actual_values, predictions, feature_order = execute_evaluation(subset_data, hyperparams)
 
     # Split the data into training sets
     train_data = subset_data[-window_size:]
     X_train, y_train = train_data.drop(columns='Output'), train_data['Output']
+    X_train = X_train[[col for col in X_train.columns if '_lag' in col]]
 
     # Initialize the XGBoost model
     model_future = xgb.XGBRegressor(
@@ -104,6 +112,7 @@ def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
     # Iterate over each forecast day and predict values
     for i in range(forecast_days):
         X_next = future_data.iloc[[i]].drop(columns='Output', errors='ignore')
+        X_next = X_next[feature_order]
 
         # Convert object columns to numeric
         for col in X_next.columns:
@@ -142,4 +151,4 @@ def execute_adaptive_xgboost(subset_data, forecast_days, hyperparams):
 
     print(future_data['Output'])
 
-    return predictions, future_data['Output']
+    return actual_values, predictions, future_data['Output'],

--- a/Utils/process_data.py
+++ b/Utils/process_data.py
@@ -32,8 +32,8 @@ def process_data_lagged_rolling_stats(data, forecast_days):
     window_sizes = [3, 14, 30]
 
     for window in window_sizes:
-        data[f'Output_{window}d_mean'] = data['Output'].rolling(window=window).mean()
-        data[f'Output_{window}d_std'] = data['Output'].rolling(window=window).std()
+        data[f'Output_lag_{window}d_mean'] = data['Output'].rolling(window=window).mean()
+        data[f'Output_lag_{window}d_std'] = data['Output'].rolling(window=window).std()
 
     data.dropna(inplace=True)
     return data


### PR DESCRIPTION
1. Bug fix for Adaptive XG-Boost of future dates creation
2. Added lag_ for rolling mean data to identify the column names with lag_
3. Removed the logic to use only lag columns from process_data, we will process all columns and use only the ones with lag where ever. More clean code like this. 

<img width="1125" alt="Screenshot 2023-10-24 at 1 26 14 PM" src="https://github.com/Nexus-Optima/Backend/assets/32458209/337acd95-8024-4da8-a1f6-38746520a77e">
<img width="1164" alt="Screenshot 2023-10-24 at 1 27 39 PM" src="https://github.com/Nexus-Optima/Backend/assets/32458209/a4ec0055-b20e-41e3-81e5-5471b631f6fa">
<img width="1119" alt="Screenshot 2023-10-24 at 1 28 04 PM" src="https://github.com/Nexus-Optima/Backend/assets/32458209/8531e0d2-a28e-47c4-84b5-877124610fba">
